### PR TITLE
feature / named parameters in values

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ which then can be used in favor of the lesser-typed default-syntax of IStringLoc
 
 [demo_typealize_translation_initial]:docs/assets/demo_typealize_translation_initial.gif
 
+# extensibilty
+
 ## customize string formatting
 
 Starting with `v0.6.x`, TypealizR supports customizing the internal usage of `string.Format()`, which should enable developers to implement #16 with the technology / library / approach at their choice - Leaving TypelaziR un-opinionated about the actual approach to achieve this.
@@ -124,6 +126,7 @@ internal static partial class TypealizR_StringFormatter
 With this implementation, every localized string would be reversed. (Even if that doesn´t make any sense ;P)
 
 
+# configuration
 ## customize warnings
 
 During code-generation, the `code-generator` might emit one of [these diagnostics](https://github.com/earloc/TypealizR/tree/main/docs/reference).

--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ which then can be used in favor of the lesser-typed default-syntax of IStringLoc
 
 [demo_typealize_translation_initial]:docs/assets/demo_typealize_translation_initial.gif
 
+## customize string formatting
+
+Starting with `v0.6.x`, TypealizR supports customizing the internal usage of `string.Format()`, which should enable developers to implement #16 with the technology / library / approach at their choice - Leaving TypelaziR un-opinionated about the actual approach to achieve this.
+
+To customize the formatting, just drop a custom implementation of `TypealizR_StringFormatter` anywhere in the project. The types `namespace` MUST match the project´s root-namespace.
+
+### example
+Given the root-namespace `TypealizR.Ockz` for the project consuming TypealizR, this partial-class declaration should be enough:
+
+```csharp
+namespace TypealizR.Ockz;
+internal static partial class TypealizR_StringFormatter
+{
+	internal static partial string Format(string s, object[] args) => 
+		new(string.Format(s, args).Reverse().ToArray());
+}
+```
+
+With this implementation, every localized string would be reversed. (Even if that doesn´t make any sense ;P)
+
 
 ## customize warnings
 

--- a/src/TypealizR.SourceGenerators.Playground.Console/.globalconfig
+++ b/src/TypealizR.SourceGenerators.Playground.Console/.globalconfig
@@ -1,5 +1,5 @@
 is_global = true
 
-dotnet_diagnostic_TR0002_severity = warning
-dotnet_diagnostic_TR0003_severity = warning
-dotnet_diagnostic_TR0004_severity = warning
+dotnet_diagnostic_TR0002_severity = hidden
+dotnet_diagnostic_TR0003_severity = hidden
+dotnet_diagnostic_TR0004_severity = hidden

--- a/src/TypealizR.SourceGenerators.Playground.Console/Demo.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/Demo.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
-
-namespace TypealizR.SourceGenerators.Playground.Console;
+	namespace TypealizR.SourceGenerators.Playground.Console;
 internal class Demo
 {
 

--- a/src/TypealizR.SourceGenerators.Playground.Console/Demo.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/Demo.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
-	namespace TypealizR.SourceGenerators.Playground.Console;
+namespace TypealizR.SourceGenerators.Playground.Console;
 internal class Demo
 {
 

--- a/src/TypealizR.SourceGenerators.Playground.Console/Program.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Localization;
 using TypealizR.SourceGenerators.Playground.Console;
 
 var services = new ServiceCollection();
+services.AddLogging();
 services.AddLocalization();
 var provider = services.BuildServiceProvider();
 
@@ -17,3 +18,5 @@ Console.WriteLine(localize.Hello__UserName(UserName: "Arthur"));
 var today = DateOnly.FromDateTime(DateTime.Now);
 
 Console.WriteLine(localize.Hello__name__today_is__now(name: "Arthur", now: today));
+
+Microsoft.Extensions.Localization.ResourceManagerStringLocalizer

--- a/src/TypealizR.SourceGenerators.Playground.Console/Program.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/Program.cs
@@ -18,5 +18,3 @@ Console.WriteLine(localize.Hello__UserName(UserName: "Arthur"));
 var today = DateOnly.FromDateTime(DateTime.Now);
 
 Console.WriteLine(localize.Hello__name__today_is__now(name: "Arthur", now: today));
-
-Microsoft.Extensions.Localization.ResourceManagerStringLocalizer

--- a/src/TypealizR.SourceGenerators.Playground.Console/TypealizR.SourceGenerators.Playground.Console.csproj
+++ b/src/TypealizR.SourceGenerators.Playground.Console/TypealizR.SourceGenerators.Playground.Console.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
@@ -8,9 +8,6 @@ using Microsoft.Extensions.Localization;
 namespace TypealizR.SourceGenerators.Playground.Console;
 internal static partial class TypealizR_StringFormatter
 {
-	public static partial LocalizedString Format(this LocalizedString that, params object[] args)
-	{
-		var value = string.Format(that.Value, args);
-		return new(that.Name, new string(value.Reverse().ToArray()), that.ResourceNotFound, that.SearchedLocation);
-	}
+	internal static partial string Format(string s, object[] args) 
+		=> new(string.Format(s, args).Reverse().ToArray());
 }

--- a/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+
+namespace TypealizR.SourceGenerators.Playground.Console;
+internal static partial class TypealizR_StringFormatter
+{
+	public static partial LocalizedString Format(this LocalizedString that, params object[] args)
+	{
+		var value = string.Format(that.Value, args);
+		return new(that.Name, new string(value.Reverse().ToArray()), that.ResourceNotFound, that.SearchedLocation);
+	}
+}

--- a/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
+++ b/src/TypealizR.SourceGenerators.Playground.Console/TypealizR_StringFormatter.cs
@@ -8,6 +8,5 @@ using Microsoft.Extensions.Localization;
 namespace TypealizR.SourceGenerators.Playground.Console;
 internal static partial class TypealizR_StringFormatter
 {
-	internal static partial string Format(string s, object[] args) 
-		=> new(string.Format(s, args).Reverse().ToArray());
+	internal static partial string Format(string s, object[] args) => new(string.Format(s, args).Reverse().ToArray());
 }

--- a/src/TypealizR.SourceGenerators.Tests/ClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/ClassBuilder.Tests.cs
@@ -33,7 +33,7 @@ public class ClassBuilder_Tests
             Name = "SomeKey",
             Signature = "(this IStringLocalizer<Name.Space.TypeName> that)",
             Body = @"that[""SomeKey""]"
-        };
+		};
 
         var actual = new
         {

--- a/src/TypealizR.SourceGenerators.Tests/ClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/ClassBuilder.Tests.cs
@@ -21,7 +21,7 @@ public class ClassBuilder_Tests
 
         sut.WithMethodFor("SomeKey", "SomeValue", 0);
 
-        var classInfo = sut.Build(new("Name.Space", "TypeName"));
+        var classInfo = sut.Build(new("Name.Space", "TypeName"), "RootName.Space");
 
         classInfo.Methods.Should().HaveCount(1);
 
@@ -58,7 +58,7 @@ public class ClassBuilder_Tests
 		sut.WithMethodFor(firstKey, "SomeValue", 10);
 		sut.WithMethodFor(duplicateKey, "SomeOtherValue", 20);
 
-        var extensionClass = sut.Build(new("Name.Space", "TypeName"));
+        var extensionClass = sut.Build(new("Name.Space", "TypeName"), "RootName.Space");
 
         var firstMethod = extensionClass.Methods.First();
 
@@ -84,7 +84,7 @@ public class ClassBuilder_Tests
 
         sut.WithMethodFor(input, "some value", 30);
 
-		var extensionClass = sut.Build(new("Name.Space", "TypeName"));
+		var extensionClass = sut.Build(new("Name.Space", "TypeName"), "RootName.Space");
 
 		var actual = extensionClass.Diagnostics.Select(x => x.Id);
 
@@ -105,7 +105,7 @@ public class ClassBuilder_Tests
 
 		sut.WithMethodFor(input, "some value", 30);
 
-		var extensionClass = sut.Build(new("Name.Space", "TypeName"));
+		var extensionClass = sut.Build(new("Name.Space", "TypeName"), "RootName.Space");
 
 		var actual = extensionClass.Diagnostics.Select(x => x.Id);
 

--- a/src/TypealizR.SourceGenerators.Tests/MethodBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/MethodBuilder.Tests.cs
@@ -136,7 +136,7 @@ public class MethodBuilder_Tests
 		var method = sut.Build(targetType);
 
 		var actual = method.Body;
-		var expected = $@"that[""{input}"", {expectedInvocation}]";
+		var expected = $@"that[""{input}""].Format({expectedInvocation})";
 
 		actual.Should().Be(expected);
 	}

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -13,7 +13,7 @@ public class StringFormatterClassBuilder_Tests
 		var sut = new StringFormatterClassBuilder("Some.Name.Space");
 		sut.UserModeImplementationIsProvided();
 
-		var actual = sut.Build().Trim().Split("\r\n"); ;
+		var actual = sut.Build().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		var expected = $@"
 namespace global::Some.Name.Space {{
@@ -31,7 +31,7 @@ namespace global::Some.Name.Space {{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
 	}}
 }}
-".Trim().Split("\r\n");
+".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		actual.Should().BeEquivalentTo(expected);
 

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -21,21 +21,17 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 
 namespace Some.Name.Space {{
-	{_.GeneratedCodeAttribute}
-	[DebuggerStepThrough]
-	internal static partial class TypealizR_StringFormatter
-	{{
+	internal static partial class {StringFormatterClassBuilder.TypeName} 
+    {{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}
-
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
-	internal static partial class TypealizR_StringFormatter
-	{{
-		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
+	internal static partial class {StringFormatterClassBuilder.TypeName} {{
+		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
 	}}
 }}
-".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		actual.Should().BeEquivalentTo(expected);
 
@@ -54,9 +50,7 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 
 namespace Some.Name.Space {{
-	{_.GeneratedCodeAttribute}
-	[DebuggerStepThrough]
-	internal static partial class TypealizR_StringFormatter
+	internal static partial class {StringFormatterClassBuilder.TypeName}
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -21,18 +21,19 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 
 namespace Some.Name.Space {{
-	internal static partial class {StringFormatterClassBuilder.TypeName} 
-    {{
-		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
+	internal static partial class {StringFormatterClassBuilder.TypeName}
+	{{
+		internal static LocalizedString Format(this LocalizedString that, params object[] args) => 
+			new LocalizedString(that.Name, Format(that.Value, args), that.ResourceNotFound, searchedLocation: that.SearchedLocation);
+
+		internal static partial string Format(string s, object[] args);
 	}}
 
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class {StringFormatterClassBuilder.TypeName} {{
-		public static partial LocalizedString Format(this LocalizedString that, params object[] args) {{ 
-			var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
-			return new LocalizedString(that.Name, formattedValue, that.ResourceNotFound, searchedLocation: that.SearchedLocation);
-		}}
+		internal static partial string Format(string s, object[] args) => 
+			string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
 	}}
 }}
 ".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -56,7 +57,10 @@ using Microsoft.Extensions.Localization;
 namespace Some.Name.Space {{
 	internal static partial class {StringFormatterClassBuilder.TypeName}
 	{{
-		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
+		internal static LocalizedString Format(this LocalizedString that, params object[] args) => 
+			new LocalizedString(that.Name, Format(that.Value, args), that.ResourceNotFound, searchedLocation: that.SearchedLocation);
+
+		internal static partial string Format(string s, object[] args);
 	}}
 }}
 ".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -13,7 +13,7 @@ public class StringFormatterClassBuilder_Tests
 		var sut = new StringFormatterClassBuilder("Some.Name.Space");
 		sut.UserModeImplementationIsProvided();
 
-		var actual = sut.Build().Trim();
+		var actual = sut.Build().Trim().Split("\r\n"); ;
 
 		var expected = $@"
 namespace global::Some.Name.Space {{
@@ -31,9 +31,9 @@ namespace global::Some.Name.Space {{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
 	}}
 }}
-".Trim();
+".Trim().Split("\r\n");
 
-		actual.Should().Be(expected);
+		actual.Should().BeEquivalentTo(expected);
 
 	}
 

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -8,12 +8,12 @@ public class StringFormatterClassBuilder_Tests
 {
 
 	[Fact]
-	public void Generates_DefaultImplementation_When_UserImplementation_Is_Not_Provided()
+	public void Generates_DefaultImplementation_When_UserImplementation_Is_NOT_Provided()
 	{
 		var sut = new StringFormatterClassBuilder("Some.Name.Space");
 		sut.UserModeImplementationIsProvided();
 
-		var actual = sut.Build().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		var expected = $@"
 namespace global::Some.Name.Space {{
@@ -29,6 +29,28 @@ namespace global::Some.Name.Space {{
 	internal static partial class TypealizR_StringFormatter
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
+	}}
+}}
+".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+
+		actual.Should().BeEquivalentTo(expected);
+
+	}
+
+	[Fact]
+	public void DoesNot_Generates_DefaultImplementation_When_UserImplementation_IS_Provided()
+	{
+		var sut = new StringFormatterClassBuilder("Some.Name.Space");
+
+		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+
+		var expected = $@"
+namespace global::Some.Name.Space {{
+	{_.GeneratedCodeAttribute}
+	[DebuggerStepThrough]
+	internal static partial class TypealizR_StringFormatter
+	{{
+		public static partial string Format(this LocalizedString s, params object[] args);
 	}}
 }}
 ".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -1,0 +1,40 @@
+﻿
+using System.Globalization;
+using FluentAssertions;
+using TypealizR.SourceGenerators.Extensibility;
+
+namespace TypealizR.SourceGenerators.Tests;
+public class StringFormatterClassBuilder_Tests
+{
+
+	[Fact]
+	public void Generates_DefaultImplementation_When_UserImplementation_Is_Not_Provided()
+	{
+		var sut = new StringFormatterClassBuilder("Some.Name.Space");
+		sut.UserModeImplementationIsProvided();
+
+		var actual = sut.Build().Trim();
+
+		var expected = $@"
+namespace global::Some.Name.Space {{
+	{_.GeneratedCodeAttribute}
+	[DebuggerStepThrough]
+	internal static partial class TypealizR_StringFormatter
+	{{
+		public static partial string Format(this LocalizedString s, params object[] args);
+	}}
+
+	{_.GeneratedCodeAttribute}
+	[DebuggerStepThrough]
+	internal static partial class TypealizR_StringFormatter
+	{{
+		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
+	}}
+}}
+".Trim();
+
+		actual.Should().Be(expected);
+
+	}
+
+}

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -63,7 +63,7 @@ namespace Some.Name.Space {{
 		internal static partial string Format(string s, object[] args);
 	}}
 }}
-".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		actual.Should().BeEquivalentTo(expected);
 	}

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -13,7 +13,7 @@ public class StringFormatterClassBuilder_Tests
 		var sut = new StringFormatterClassBuilder("Some.Name.Space");
 		sut.UserModeImplementationIsProvided();
 
-		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
 		var expected = $@"
 using System.Diagnostics;
@@ -25,13 +25,14 @@ namespace Some.Name.Space {{
     {{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}
+
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class {StringFormatterClassBuilder.TypeName} {{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
 	}}
 }}
-".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
 		actual.Should().BeEquivalentTo(expected);
 
@@ -58,7 +59,5 @@ namespace Some.Name.Space {{
 ".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		actual.Should().BeEquivalentTo(expected);
-
 	}
-
 }

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -20,7 +20,7 @@ using System.Diagnostics;
 using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 
-namespace global::Some.Name.Space {{
+namespace Some.Name.Space {{
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class TypealizR_StringFormatter
@@ -53,7 +53,7 @@ using System.Diagnostics;
 using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 
-namespace global::Some.Name.Space {{
+namespace Some.Name.Space {{
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class TypealizR_StringFormatter

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -23,13 +23,16 @@ using Microsoft.Extensions.Localization;
 namespace Some.Name.Space {{
 	internal static partial class {StringFormatterClassBuilder.TypeName} 
     {{
-		public static partial string Format(this LocalizedString s, params object[] args);
+		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
 	}}
 
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class {StringFormatterClassBuilder.TypeName} {{
-		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+		public static partial LocalizedString Format(this LocalizedString that, params object[] args) {{ 
+			var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+			return new LocalizedString(that.Name, formattedValue, that.ResourceNotFound, searchedLocation: that.SearchedLocation);
+		}}
 	}}
 }}
 ".Trim().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -53,7 +56,7 @@ using Microsoft.Extensions.Localization;
 namespace Some.Name.Space {{
 	internal static partial class {StringFormatterClassBuilder.TypeName}
 	{{
-		public static partial string Format(this LocalizedString s, params object[] args);
+		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
 	}}
 }}
 ".Trim().Split("\r\n", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);

--- a/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
+++ b/src/TypealizR.SourceGenerators.Tests/StringFormatterClassBuilder.Tests.cs
@@ -16,6 +16,10 @@ public class StringFormatterClassBuilder_Tests
 		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		var expected = $@"
+using System.Diagnostics;
+using System.CodeDom.Compiler;
+using Microsoft.Extensions.Localization;
+
 namespace global::Some.Name.Space {{
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
@@ -45,6 +49,10 @@ namespace global::Some.Name.Space {{
 		var actual = sut.Build().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
 
 		var expected = $@"
+using System.Diagnostics;
+using System.CodeDom.Compiler;
+using Microsoft.Extensions.Localization;
+
 namespace global::Some.Name.Space {{
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]

--- a/src/TypealizR.SourceGenerators/DiagnosticsFactory.cs
+++ b/src/TypealizR.SourceGenerators/DiagnosticsFactory.cs
@@ -65,7 +65,7 @@ internal class DiagnosticsFactory
 		Diagnostic.Create(
 			new(id: TR0003.Id.ToString(),
 				title: TR0003.Title,
-				messageFormat: "Ressource-key '{0}' uses the generic format-parameter '{1}'. Consider to to use a more meaningful name, instead. See {2}",
+				messageFormat: "Ressource-key '{0}' uses the generic format-parameter '{1}'. Consider to use a more meaningful name, instead. See {2}",
 				category: "Readability",
 				defaultSeverity: SeverityFor(TR0003.Id) ?? DiagnosticSeverity.Warning,
 				isEnabledByDefault: true,

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -62,7 +62,7 @@ using Microsoft.Extensions.Localization;
 		[DebuggerStepThrough]
 		internal static partial class {TypeName} {{
 			public static partial LocalizedString Format(this LocalizedString that, params object[] args) {{ 
-				var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+				var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, that.Value, args);
 				return new LocalizedString(that.Name, formattedValue, that.ResourceNotFound, searchedLocation: that.SearchedLocation);
 			}}
 		}}

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -6,6 +6,8 @@ using System.Text;
 namespace TypealizR.SourceGenerators.Extensibility;
 internal class StringFormatterClassBuilder
 {
+	public static string TypeName = "TypealizR_StringFormatter";
+
 	private string rootNamespace;
 
 	public StringFormatterClassBuilder(string rootNamespace)
@@ -54,7 +56,7 @@ using Microsoft.Extensions.Localization;
 	private string GenerateStub() => $@"
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
-	internal static partial class TypealizR_StringFormatter
+	internal static partial class {TypeName}
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}";
@@ -62,7 +64,7 @@ using Microsoft.Extensions.Localization;
 	private static string GenerateDefaultImplementation() => $@"
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
-	internal static partial class TypealizR_StringFormatter
+	internal static partial class {TypeName}
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
 	}}";

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using System.Collections.Generic;
 using System.Text;
 
@@ -17,6 +18,8 @@ internal class StringFormatterClassBuilder
 
 	internal string Build()
 	{
+		
+
 		string stringFormatterStub = GenerateStub();
 
 		var defaultImplementation = default(string?);
@@ -26,6 +29,8 @@ internal class StringFormatterClassBuilder
 		}
 
 		var builder = new StringBuilder();
+
+		builder.Append(GenerateUsings());
 		builder.AppendLine(OpenNamespace(this.rootNamespace));
 		builder.AppendLine(stringFormatterStub);
 
@@ -35,9 +40,14 @@ internal class StringFormatterClassBuilder
 		}
 
 		builder.AppendLine(CloseNamespace());
-
 		return builder.ToString();
 	}
+
+	private string GenerateUsings() => $@"
+using System.Diagnostics;
+using System.CodeDom.Compiler;
+using Microsoft.Extensions.Localization;
+";
 
 	private string OpenNamespace(string rootNamespace) =>$@"namespace global::{rootNamespace} {{";
 

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -17,8 +17,34 @@ internal class StringFormatterClassBuilder
 
 	internal string Build()
 	{
-		var stringFormatterStub = $@"
-namespace global::Some.Name.Space {{
+
+		string stringFormatterStub = GenerateStub();
+
+		var defaultImplementation = default(string?);
+		if (isUserModeImplementationProvided)
+		{
+			defaultImplementation = GenerateDefaultImplementation();
+		}
+
+		var builder = new StringBuilder();
+		builder.AppendLine(OpenNamespace(this.rootNamespace));
+		builder.AppendLine(stringFormatterStub);
+
+		if (!string.IsNullOrEmpty(defaultImplementation))
+		{
+			builder.AppendLine(defaultImplementation);
+		}
+
+		builder.AppendLine(CloseNamespace());
+
+		return builder.ToString();
+	}
+
+
+
+	private string OpenNamespace(string rootNamespace) =>$@"namespace global::{rootNamespace} {{";
+
+	private string GenerateStub() => $@"
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class TypealizR_StringFormatter
@@ -26,26 +52,14 @@ namespace global::Some.Name.Space {{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}";
 
-		var defaultImplementation = default(string?);
-		if (isUserModeImplementationProvided)
-		{
-			defaultImplementation = $@"
+	private static string GenerateDefaultImplementation() => $@"
 	{_.GeneratedCodeAttribute}
 	[DebuggerStepThrough]
 	internal static partial class TypealizR_StringFormatter
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
 	}}";
-		}
 
-		var builder = new StringBuilder();
-		builder.AppendLine(stringFormatterStub);
-		if (!string.IsNullOrEmpty(defaultImplementation))
-		{
-			builder.AppendLine(defaultImplementation);
-		}
-		builder.AppendLine("}");
-
-		return builder.ToString();
-	}
+	private string CloseNamespace() => "}";
 }
+

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -8,7 +8,7 @@ internal class StringFormatterClassBuilder
 {
 	public static string TypeName = "TypealizR_StringFormatter";
 
-	private string rootNamespace;
+	private readonly string rootNamespace;
 
 	public StringFormatterClassBuilder(string rootNamespace)
 	{
@@ -54,14 +54,17 @@ using Microsoft.Extensions.Localization;
 	private string GenerateStub() => $@"
 	internal static partial class {TypeName}
 	{{
-		public static partial string Format(this LocalizedString s, params object[] args);
+		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
 	}}";
 
 	private static string GenerateDefaultImplementation() => $@"
 		{_.GeneratedCodeAttribute}
 		[DebuggerStepThrough]
 		internal static partial class {TypeName} {{
-			public static partial string Format(this LocalizedString s, params object[] args) => string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+			public static partial LocalizedString Format(this LocalizedString that, params object[] args) {{ 
+				var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+				return new LocalizedString(that.Name, formattedValue, that.ResourceNotFound, searchedLocation: that.SearchedLocation);
+			}}
 		}}
 ";
 

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -20,8 +20,6 @@ internal class StringFormatterClassBuilder
 
 	internal string Build()
 	{
-		
-
 		string stringFormatterStub = GenerateStub();
 
 		var defaultImplementation = default(string?);
@@ -54,20 +52,18 @@ using Microsoft.Extensions.Localization;
 	private string OpenNamespace(string rootNamespace) =>$@"namespace {rootNamespace} {{";
 
 	private string GenerateStub() => $@"
-	{_.GeneratedCodeAttribute}
-	[DebuggerStepThrough]
 	internal static partial class {TypeName}
 	{{
 		public static partial string Format(this LocalizedString s, params object[] args);
 	}}";
 
 	private static string GenerateDefaultImplementation() => $@"
-	{_.GeneratedCodeAttribute}
-	[DebuggerStepThrough]
-	internal static partial class {TypeName}
-	{{
-		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
-	}}";
+		{_.GeneratedCodeAttribute}
+		[DebuggerStepThrough]
+		internal static partial class {TypeName} {{
+			public static partial string Format(this LocalizedString s, params object[] args) => string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
+		}}
+";
 
 	private string CloseNamespace() => "}";
 }

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TypealizR.SourceGenerators.Extensibility;
+internal class StringFormatterClassBuilder
+{
+	private string rootNamespace;
+
+	public StringFormatterClassBuilder(string rootNamespace)
+	{
+		this.rootNamespace = rootNamespace;
+	}
+
+	private bool isUserModeImplementationProvided = false;
+	internal void UserModeImplementationIsProvided() => isUserModeImplementationProvided = true;
+
+	internal string Build()
+	{
+		var stringFormatterStub = "a";
+
+		var defaultImplementation = default(string?);
+		if (isUserModeImplementationProvided)
+		{
+			defaultImplementation = "b";
+		}
+
+		var builder = new StringBuilder();
+		builder.AppendLine(stringFormatterStub);
+		if (!string.IsNullOrEmpty(defaultImplementation))
+		{
+			builder.AppendLine(defaultImplementation);
+		}
+
+		return builder.ToString();
+	}
+}

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -17,12 +17,25 @@ internal class StringFormatterClassBuilder
 
 	internal string Build()
 	{
-		var stringFormatterStub = "a";
+		var stringFormatterStub = $@"
+namespace global::Some.Name.Space {{
+	{_.GeneratedCodeAttribute}
+	[DebuggerStepThrough]
+	internal static partial class TypealizR_StringFormatter
+	{{
+		public static partial string Format(this LocalizedString s, params object[] args);
+	}}";
 
 		var defaultImplementation = default(string?);
 		if (isUserModeImplementationProvided)
 		{
-			defaultImplementation = "b";
+			defaultImplementation = $@"
+	{_.GeneratedCodeAttribute}
+	[DebuggerStepThrough]
+	internal static partial class TypealizR_StringFormatter
+	{{
+		public static partial string Format(this LocalizedString s, params object[] args) => string.Format(global::System.Globalization.CultureInfo.CurrentCulture, s, args)
+	}}";
 		}
 
 		var builder = new StringBuilder();
@@ -31,6 +44,7 @@ internal class StringFormatterClassBuilder
 		{
 			builder.AppendLine(defaultImplementation);
 		}
+		builder.AppendLine("}");
 
 		return builder.ToString();
 	}

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -54,17 +54,18 @@ using Microsoft.Extensions.Localization;
 	private string GenerateStub() => $@"
 	internal static partial class {TypeName}
 	{{
-		public static partial LocalizedString Format(this LocalizedString that, params object[] args);
+		internal static LocalizedString Format(this LocalizedString that, params object[] args) => 
+			new LocalizedString(that.Name, Format(that.Value, args), that.ResourceNotFound, searchedLocation: that.SearchedLocation);
+
+		internal static partial string Format(string s, object[] args);
 	}}";
 
 	private static string GenerateDefaultImplementation() => $@"
 		{_.GeneratedCodeAttribute}
 		[DebuggerStepThrough]
 		internal static partial class {TypeName} {{
-			public static partial LocalizedString Format(this LocalizedString that, params object[] args) {{ 
-				var formattedValue = string.Format(System.Globalization.CultureInfo.CurrentCulture, that.Value, args);
-				return new LocalizedString(that.Name, formattedValue, that.ResourceNotFound, searchedLocation: that.SearchedLocation);
-			}}
+			internal static partial string Format(string s, object[] args) => 
+				string.Format(System.Globalization.CultureInfo.CurrentCulture, s, args);
 		}}
 ";
 

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -49,7 +49,7 @@ using System.CodeDom.Compiler;
 using Microsoft.Extensions.Localization;
 ";
 
-	private string OpenNamespace(string rootNamespace) =>$@"namespace global::{rootNamespace} {{";
+	private string OpenNamespace(string rootNamespace) =>$@"namespace {rootNamespace} {{";
 
 	private string GenerateStub() => $@"
 	{_.GeneratedCodeAttribute}

--- a/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/Extensibility/StringFormatterClassBuilder.cs
@@ -17,7 +17,6 @@ internal class StringFormatterClassBuilder
 
 	internal string Build()
 	{
-
 		string stringFormatterStub = GenerateStub();
 
 		var defaultImplementation = default(string?);
@@ -39,8 +38,6 @@ internal class StringFormatterClassBuilder
 
 		return builder.ToString();
 	}
-
-
 
 	private string OpenNamespace(string rootNamespace) =>$@"namespace global::{rootNamespace} {{";
 

--- a/src/TypealizR.SourceGenerators/StringLocalizer/ClassBuilder.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/ClassBuilder.cs
@@ -25,7 +25,7 @@ internal class ClassBuilder
 		return this;
 	}
 
-	public ClassModel Build(TypeModel target)
+	public ClassModel Build(TypeModel target, string rootNamespace)
 	{
 		var methods = methodBuilders
 			.Select(x => x.Build(target))
@@ -44,7 +44,7 @@ internal class ClassBuilder
 			.Concat(parameterDiagnostics)
 		;
 
-		return new(target, distinctMethods, allWarningsAndErrors);
+		return new(target, rootNamespace, distinctMethods, allWarningsAndErrors);
     }
 
 	private IEnumerable<MethodModel> Deduplicate(MethodModel[] methods)

--- a/src/TypealizR.SourceGenerators/StringLocalizer/ClassModel.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/ClassModel.cs
@@ -10,16 +10,17 @@ namespace TypealizR.SourceGenerators.StringLocalizer;
 internal class ClassModel
 {
     private readonly TypeModel target;
-
-    private readonly string members;
+	private readonly string rootNamespace;
+	private readonly string members;
 
     public IEnumerable<MethodModel> Methods { get; }
     public IEnumerable<Diagnostic> Diagnostics { get; }
 
-	public ClassModel(TypeModel target, IEnumerable<MethodModel> methods, IEnumerable<Diagnostic> warningsAndErrors)
+	public ClassModel(TypeModel target, string rootNamespace, IEnumerable<MethodModel> methods, IEnumerable<Diagnostic> warningsAndErrors)
     {
         this.target = target;
-        Methods = methods;
+		this.rootNamespace = rootNamespace;
+		Methods = methods;
 		Diagnostics = warningsAndErrors;
 		members = string.Join("\r", methods
             .Select(x => x.Declaration)
@@ -34,7 +35,7 @@ internal class ClassModel
 using System.CodeDom.Compiler;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Localization;
+using {rootNamespace};
 using {target.Namespace};
 namespace Microsoft.Extensions.Localization {{
 

--- a/src/TypealizR.SourceGenerators/StringLocalizer/ClassModel.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/ClassModel.cs
@@ -9,9 +9,6 @@ namespace TypealizR.SourceGenerators.StringLocalizer;
 
 internal class ClassModel
 {
-    private static readonly string generatorName = typeof(SourceGenerator).FullName;
-    private static readonly Version generatorVersion = typeof(SourceGenerator).Assembly.GetName().Version;
-
     private readonly TypeModel target;
 
     private readonly string members;
@@ -41,11 +38,8 @@ using Microsoft.Extensions.Localization;
 using {target.Namespace};
 namespace Microsoft.Extensions.Localization {{
 
-    [
-        GeneratedCode(""{generatorName}"", ""{generatorVersion}""),
-        DebuggerStepThrough,
-        ExcludeFromCodeCoverage(Justification = ""generated code"")
-    ]
+    {_.GeneratedCodeAttribute}
+    [DebuggerStepThrough]
     internal static partial class IStringLocalizerExtensions_{target.Name}
     {{
     {members}

--- a/src/TypealizR.SourceGenerators/StringLocalizer/MethodModel.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/MethodModel.cs
@@ -46,7 +46,7 @@ internal class MethodModel
             Signature = $"({ThisParameterFor(t)}, {additionalParameterDeclarations})";
 
             var parameterCollection = string.Join(", ", Parameters.Select(x => x.Name));
-            Body = $@"that[""{rawRessourceName}"", {parameterCollection}]";
+            Body = Body = $@"that[""{rawRessourceName}""].Format({parameterCollection})";
         }
     }
 

--- a/src/TypealizR.SourceGenerators/StringLocalizer/SourceGenerator.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/SourceGenerator.cs
@@ -57,7 +57,7 @@ public partial class SourceGenerator : IIncrementalGenerator
                 var targetTypeName = file.SimpleName;
 
                 var targetNamespace = FindNameSpaceOf(options.RootNamespace, file.FullPath, options.ProjectDirectory.FullName);
-                var extensionClass = builder.Build(new (targetNamespace, file.SimpleName));
+                var extensionClass = builder.Build(new(targetNamespace, file.SimpleName), options.RootNamespace);
 
 				ctxt.AddSource(extensionClass.FileName, extensionClass.Body);
 

--- a/src/TypealizR.SourceGenerators/StringLocalizer/SourceGenerator.cs
+++ b/src/TypealizR.SourceGenerators/StringLocalizer/SourceGenerator.cs
@@ -12,11 +12,12 @@ namespace TypealizR.SourceGenerators.StringLocalizer;
 [Generator]
 public partial class SourceGenerator : IIncrementalGenerator
 {
+	private const string ResXFileExtension = ".resx";
 
-    public void Initialize(IncrementalGeneratorInitializationContext context)
+	public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var settings = context.AnalyzerConfigOptionsProvider.Select((x, cancel) => Options.From(x.GlobalOptions));
-		var allResxFiles = context.AdditionalTextsProvider.Where(static x => x.Path.EndsWith(".resx"));
+		var allResxFiles = context.AdditionalTextsProvider.Where(static x => x.Path.EndsWith(ResXFileExtension));
         var monitoredFiles = allResxFiles.Collect().Select((x, cancel) => RessourceFile.From(x));
 		var stringFormatterProvided = context.CompilationProvider.Select((x, cancel) => !x.ContainsSymbolsWithName(StringFormatterClassBuilder.TypeName, SymbolFilter.Type));
 

--- a/src/TypealizR.SourceGenerators/_.cs
+++ b/src/TypealizR.SourceGenerators/_.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using TypealizR.SourceGenerators.StringLocalizer;
 
 [assembly: InternalsVisibleTo("TypealizR.SourceGenerators.Tests")]
 
@@ -10,4 +11,8 @@ namespace TypealizR.SourceGenerators;
 
 internal abstract class _
 {
+	private static readonly string generatorName = typeof(SourceGenerator).FullName;
+	private static readonly Version generatorVersion = typeof(SourceGenerator).Assembly.GetName().Version;
+
+	public static readonly string GeneratedCodeAttribute = $@"[GeneratedCode(""{generatorName}"", ""{generatorVersion}"")]";
 }


### PR DESCRIPTION
# extensibilty

## customize string formatting

Starting with `v0.6.x`, TypealizR supports customizing the internal usage of `string.Format()`, which should enable developers to implement #16 with the technology / library / approach at their choice - Leaving TypelaziR un-opinionated about the actual approach to achieve this.

To customize the formatting, just drop a custom implementation of `TypealizR_StringFormatter` anywhere in the project. The types `namespace` MUST match the project´s root-namespace.

### example
Given the root-namespace `TypealizR.Ockz` for the project consuming TypealizR, this partial-class declaration should be enough:

```csharp
namespace TypealizR.Ockz;
internal static partial class TypealizR_StringFormatter
{
	internal static partial string Format(string s, object[] args) => 
		new(string.Format(s, args).Reverse().ToArray());
}
```


Closes #41 