### PR TITLE
Bug: operation canceled

### DIFF
--- a/src/Playground.CodeFirst.Console/Playground.CodeFirst.Console.csproj
+++ b/src/Playground.CodeFirst.Console/Playground.CodeFirst.Console.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/Playground.Common/Playground.Common.csproj
+++ b/src/Playground.Common/Playground.Common.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Playground.Console/Playground.Console.csproj
+++ b/src/Playground.Console/Playground.Console.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.11" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     </ItemGroup>
 

--- a/src/TypealizR.CLI/TypealizR.CLI.csproj
+++ b/src/TypealizR.CLI/TypealizR.CLI.csproj
@@ -39,7 +39,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.6.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.1" />

--- a/src/TypealizR.Tests/TypealizR.Tests.csproj
+++ b/src/TypealizR.Tests/TypealizR.Tests.csproj
@@ -39,20 +39,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NuGet.Frameworks" Version="6.6.0" />
-        <PackageReference Include="FluentAssertions" Version="6.11.0" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.23.1">
+        <PackageReference Include="NuGet.Frameworks" Version="6.7.0" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions.Analyzers" Version="0.24.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.11" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.1.0" />
-        <PackageReference Include="Verify.Xunit" Version="20.8.2" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Verify.Xunit" Version="21.1.4" />
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/TypealizR/CodeFirstSourceGenerator/CodeFirstSourceGenerator.cs
+++ b/src/TypealizR/CodeFirstSourceGenerator/CodeFirstSourceGenerator.cs
@@ -127,7 +127,7 @@ public sealed class CodeFirstSourceGenerator : IIncrementalGenerator
             allTrivias = tree.GetCompilationUnitRoot(cancellationToken).GetLeadingTrivia().Where(x => x.HasStructure).ToArray();
         }
 
-        var documentation = allTrivias.FirstOrDefault(x => x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia));
+        var documentation = Array.Find(allTrivias, x => x.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia));
 
         if (documentation.GetStructure() is not DocumentationCommentTriviaSyntax structure)
         {

--- a/src/TypealizR/Core/RessourceFile.cs
+++ b/src/TypealizR/Core/RessourceFile.cs
@@ -87,11 +87,12 @@ public partial class RessourceFile
 
                     }
 
+                    var content = cancellationToken.IsCancellationRequested ? string.Empty : _.MainFile.Text.GetText()?.ToString() ?? string.Empty;
 
                     return new RessourceFile(
                         simpleName: _.Name,
                         fullPath: _.MainFile.Text.Path,
-                        content: _.MainFile.Text.GetText(cancellationToken)?.ToString() ?? string.Empty,
+                        content: content,
                         customToolNamespace: customToolNamespace,
                         useParamNamesInMethodNames: useParamNamesInMethodNames
                     );

--- a/src/TypealizR/Core/RessourceFile.cs
+++ b/src/TypealizR/Core/RessourceFile.cs
@@ -82,7 +82,6 @@ public partial class RessourceFile
                         && !string.IsNullOrEmpty(useParamNamesInMethodNamesItemMetadataString)
                         && bool.TryParse(useParamNamesInMethodNamesItemMetadataString, out var useParamNamesInMethodNamesItemMetadata))
                     {
-
                         useParamNamesInMethodNames = useParamNamesInMethodNamesItemMetadata;
                     }
 

--- a/src/TypealizR/Core/RessourceFile.cs
+++ b/src/TypealizR/Core/RessourceFile.cs
@@ -84,7 +84,6 @@ public partial class RessourceFile
                     {
 
                         useParamNamesInMethodNames = useParamNamesInMethodNamesItemMetadata;
-
                     }
 
                     var content = cancellationToken.IsCancellationRequested ? string.Empty : _.MainFile.Text.GetText()?.ToString() ?? string.Empty;

--- a/src/TypealizR/Core/ResxFileSourceGeneratorBase.cs
+++ b/src/TypealizR/Core/ResxFileSourceGeneratorBase.cs
@@ -104,7 +104,7 @@ public abstract class ResxFileSourceGeneratorBase : IIncrementalGenerator
             return (nameSpace.Trim('.', ' '), Accessibility.Internal);
         }
 
-        var matchingMarkerType = possibleMarkerTypeSymbols.FirstOrDefault(x => x.ContainingNamespace.OriginalDefinition.ToDisplayString() == nameSpace);
+        var matchingMarkerType = Array.Find(possibleMarkerTypeSymbols, x => x.ContainingNamespace.OriginalDefinition.ToDisplayString() == nameSpace);
 
         if (matchingMarkerType is null)
         {

--- a/src/TypealizR/Core/ResxFileSourceGeneratorBase.cs
+++ b/src/TypealizR/Core/ResxFileSourceGeneratorBase.cs
@@ -12,36 +12,41 @@ public abstract class ResxFileSourceGeneratorBase : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        try
+        {
+            var optionsProvider = context.AnalyzerConfigOptionsProvider
+                .Select((x, cancel) => GeneratorOptions.From(x.GlobalOptions)
+            );
 
-        var optionsProvider = context.AnalyzerConfigOptionsProvider
-            .Select((x, cancel) => GeneratorOptions.From(x.GlobalOptions)
-        );
+            var resxFilesProvider = context.AdditionalTextsProvider
+                .Where(static x => x.Path.EndsWith(".resx", StringComparison.Ordinal))
+                .Combine(context.AnalyzerConfigOptionsProvider)
+            ;
 
-        var resxFilesProvider = context.AdditionalTextsProvider
-            .Where(static x => x.Path.EndsWith(".resx", StringComparison.Ordinal))
-            .Combine(context.AnalyzerConfigOptionsProvider)
-        ;
+            var monitoredFiles = resxFilesProvider
+                .Select((x, cancel) => new AdditionalTextWithOptions(x.Left, x.Right.GetOptions(x.Left)))
+                .Collect()
+                .Select(RessourceFile.From)
+            ;
 
-        var monitoredFiles = resxFilesProvider
-            .Select((x, cancel) => new AdditionalTextWithOptions(x.Left, x.Right.GetOptions(x.Left)))
-            .Collect()
-            .Select(RessourceFile.From)
-        ;
-
-        context.RegisterSourceOutput(monitoredFiles
-            .Combine(optionsProvider)
-            .Combine(context.CompilationProvider),
-            (ctxt, source) =>
-            {
-                var files = source.Left.Left;
-                var options = source.Left.Right;
-                var compilation = source.Right;
-
-                foreach (var file in files)
+            context.RegisterSourceOutput(monitoredFiles
+                .Combine(optionsProvider)
+                .Combine(context.CompilationProvider),
+                (ctxt, source) =>
                 {
-                    GenerateSourceFor(ctxt, options, compilation, file);
-                }
-            });
+                    var files = source.Left.Left;
+                    var options = source.Left.Right;
+                    var compilation = source.Right;
+
+                    foreach (var file in files)
+                    {
+                        GenerateSourceFor(ctxt, options, compilation, file);
+                    }
+                });
+        }
+        catch (OperationCanceledException)
+        {
+        }
     }
 
     protected void GenerateSourceFor(SourceProductionContext ctxt, GeneratorOptions options, Compilation compilation, RessourceFile file)

--- a/src/TypealizR/TypealizR.csproj
+++ b/src/TypealizR/TypealizR.csproj
@@ -50,7 +50,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
-        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.5" PrivateAssets="all" GeneratePathProperty="true" />
+        <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="7.0.11" PrivateAssets="all" GeneratePathProperty="true" />
     </ItemGroup>
     <ItemGroup>
         <XliffResource Include="MultilingualResources\TypealizR.de.xlf" />


### PR DESCRIPTION
catch `OparetionCanceledException` thrown by consumers of `cancellationToken`, which may be done in library code.

tries to fix #166 